### PR TITLE
Fix code example

### DIFF
--- a/docs/pages/v3/helper-functions.md
+++ b/docs/pages/v3/helper-functions.md
@@ -346,7 +346,7 @@ function accrueAccount(address account) override external
 
 ```solidity
 Comet comet = Comet(0xCometAddress);
-uint price = comet.accrueAccount(0xAccount);
+comet.accrueAccount(0xAccount);
 ```
 
 #### Ethers.js v5.x


### PR DESCRIPTION
As documented above the code example, the `accrueAccount` function does not return a value.