### PR TITLE
feat(ci): support private source repo in compound-3 sync

### DIFF
--- a/.github/workflows/sync-compound-3.yml
+++ b/.github/workflows/sync-compound-3.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Sync compound-3.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: classic or fine-grained PAT with read access to the private source repo
+          # (contents: read). Leave unset if the source repo is public — behavior unchanged.
+          SOURCE_GITHUB_TOKEN: ${{ secrets.COMPOUND_3_SOURCE_REPO_TOKEN }}
         run: |
           bash scripts/sync_compound_3.sh

--- a/scripts/sync_compound_3.sh
+++ b/scripts/sync_compound_3.sh
@@ -54,16 +54,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Setup curl arguments with authentication
+# Setup curl arguments with authentication (used for this repo's GitHub API calls).
+# GitHub accepts "Authorization: Bearer <TOKEN>" for all token types (GITHUB_TOKEN,
+# classic PATs, fine-grained PATs, GitHub App tokens).
 curl_args=(-sS -L)
 if [[ -n "${GH_TOKEN:-}" ]]; then
-  curl_args+=(-H "Authorization: token ${GH_TOKEN}")
+  curl_args+=(-H "Authorization: Bearer ${GH_TOKEN}")
+fi
+
+# Token for downloading from the source repo (optional). When the source is private,
+# set SOURCE_GITHUB_TOKEN to a PAT/fine-grained token with contents:read on that repo.
+# If unset, GH_TOKEN is used so public sources keep working with only GITHUB_TOKEN.
+# --fail makes curl exit non-zero on HTTP errors (e.g. 401/403/404), so a missing or
+# insufficient token fails fast instead of writing an error JSON into the target file.
+download_token="${SOURCE_GITHUB_TOKEN:-${GH_TOKEN:-}}"
+download_curl_args=(-sS -L --fail)
+if [[ -n "${download_token}" ]]; then
+  download_curl_args+=(-H "Authorization: Bearer ${download_token}")
 fi
 
 # Download source file
 api_url="${GITHUB_API_BASE}/repos/${SOURCE_OWNER}/${SOURCE_REPO}/contents/${SOURCE_PATH}?ref=${SOURCE_BRANCH}"
 echo "Downloading source file from ${api_url}"
-curl "${curl_args[@]}" -H "Accept: application/vnd.github.v3.raw" "${api_url}" -o "${tmp_file}"
+curl "${download_curl_args[@]}" -H "Accept: application/vnd.github.v3.raw" "${api_url}" -o "${tmp_file}"
 
 mkdir -p "$(dirname "${TARGET_ABS_PATH}")"
 


### PR DESCRIPTION
## Why

The [source](https://github.com/woof-software/compound-docs-aggregator) repository for `compound-3.md` is going to be private. The default
`GITHUB_TOKEN` only has access to this repo, so a separate token is required
to read the source.

## Required action

Add a repository secret:

- **Name:** `COMPOUND_3_SOURCE_REPO_TOKEN`
- **Value:** PAT with read access to the private source repo
  (fine-grained: `Contents: Read`). We are planning to send it to you

**Settings → Secrets and variables → Actions → New repository secret.**

## Backwards compatibility

If the secret is not set, the workflow falls back to `GITHUB_TOKEN` and keeps
working unchanged for a public source.

## Details

Add optional SOURCE_GITHUB_TOKEN so the sync workflow can fetch compound-3.md from a private source repository, while keeping existing behavior for public sources.

- workflow: wire secrets.COMPOUND_3_SOURCE_REPO_TOKEN into SOURCE_GITHUB_TOKEN; falls back to GITHUB_TOKEN when unset
- script: use a separate curl arg set for the source download, authenticated with SOURCE_GITHUB_TOKEN when provided
- script: switch to "Authorization: Bearer" for all token types
- script: add --fail to the source download so HTTP errors (401/403/404) fail fast instead of writing an error payload into docs/pages/v3/compound-3.md